### PR TITLE
Re-style online lobby overlay and visibility rules

### DIFF
--- a/BGAnimations/ScreenPlayerOptions common.lua
+++ b/BGAnimations/ScreenPlayerOptions common.lua
@@ -1,5 +1,25 @@
 local af = Def.ActorFrame{}
 
+-- Append the lobby code to the header text (e.g. "Select Modifiers (ABCD)")
+-- whenever we're connected to an online lobby. Shared across ScreenPlayerOptions,
+-- ScreenPlayerOptions2, and ScreenPlayerOptions3.
+af[#af+1] = Def.Actor{
+	InitCommand=function(self) self:queuecommand("Refresh") end,
+	OnlineLobbyStateMessageCommand=function(self) self:queuecommand("Refresh") end,
+	OnlineLobbyLeftMessageCommand=function(self) self:queuecommand("Refresh") end,
+	DisconnectOnlineMessageCommand=function(self) self:queuecommand("Refresh") end,
+	RefreshCommand=function(self)
+		local handler = GetOnlineHandlerInstance()
+		local lobbyCode = handler and handler.lobbyCode
+		local screenName = SCREENMAN:GetTopScreen():GetName()
+		local headerText = THEME:GetString(screenName, "HeaderText")
+		if lobbyCode then
+			headerText = ("%s (%s)"):format(headerText, lobbyCode)
+		end
+		MESSAGEMAN:Broadcast("SetHeaderText", {Text=headerText})
+	end
+}
+
 -- this is broadcast from [OptionRow] TitleGainFocusCommand in metrics.ini
 -- we use it to color the active OptionRow's title appropriately by PlayerColor()
 af.OptionRowChangedMessageCommand=function(self, params)

--- a/BGAnimations/ScreenPlayerOptions overlay/default.lua
+++ b/BGAnimations/ScreenPlayerOptions overlay/default.lua
@@ -294,6 +294,9 @@ LoadActor("./OptionRowPreviews/HoldJudgment.lua", t)
 LoadActor("./OptionRowPreviews/MusicRate.lua", t)
 
 -- some functionality needed in both PlayerOptions, PlayerOptions2, and PlayerOptions3
+-- (this also includes appending the lobby code to the header text; see
+-- "ScreenPlayerOptions common.lua", since ScreenPlayerOptions2 and
+-- ScreenPlayerOptions3 load that file directly as their own overlay)
 t[#t+1] = LoadActor(THEME:GetPathB("ScreenPlayerOptions", "common"))
 
 

--- a/Scripts/SL-OnlineHelpers.lua
+++ b/Scripts/SL-OnlineHelpers.lua
@@ -344,8 +344,6 @@ local DisplayLobbyState = function(data, actor)
 
       if screenName == Branch.GameplayScreen() then
         SCREENMAN:GetTopScreen():PauseGame(false)
-        -- Hide the sync/scoreboard panel once gameplay actually starts.
-        actor:GetChild("Display"):visible(false)
       end
     else
       lines[#lines+1] = "Waiting for players to sync screens...\n"
@@ -581,11 +579,6 @@ CreateOnlineHandler = function()
             MESSAGEMAN:Broadcast("DisconnectOnline")
             return
           end
-
-          -- The panel gets hidden once gameplay actually starts; bring it back
-          -- whenever we land on a new screen so syncing/scores are visible again.
-          -- ScreenEvaluationStage never shows it.
-          self:GetChild("Display"):visible(screenName ~= "ScreenEvaluationStage")
 
           -- Lock input while syncing arrival on key screens.
           if syncLockScreens[screenName] then

--- a/Scripts/SL-OnlineHelpers.lua
+++ b/Scripts/SL-OnlineHelpers.lua
@@ -352,7 +352,7 @@ local DisplayLobbyState = function(data, actor)
       end
     end
   end
-  for i, player in ipairs(updatedData.players) do
+  for _, player in ipairs(updatedData.players) do
     local displayedScreen = player.screenName ~= "NoScreen" and player.screenName:gsub("Screen", "") or "Transitioning"
     local readyText = ""
     if screenName == Branch.GameplayScreen() and not updatedData.aux.allPlayersReady then
@@ -361,28 +361,24 @@ local DisplayLobbyState = function(data, actor)
 
     -- Only display the screen name of the players that are on a different
     -- screen than we are.
-    local playerAndScreen = i..'. '..player.profileName..readyText
+    local playerAndScreen = player.profileName..readyText
     if screenName ~= player.screenName then
       playerAndScreen = playerAndScreen.." - in "..displayedScreen
     end
 
     lines[#lines+1] = playerAndScreen
-    for scoreScreen in ivalues(scoreScreens) do
-      if player.screenName == scoreScreen then
-        -- Display the score and EX score.
-        local score = (player.score ~= nil and player.score) or 0
-        local exScore = (player.exScore ~= nil and player.exScore) or 0
+    if screenName ~= "ScreenSelectMusic" then
+      for scoreScreen in ivalues(scoreScreens) do
+        if player.screenName == scoreScreen then
+          -- Display the EX score only.
+          local exScore = (player.exScore ~= nil and player.exScore) or 0
+          local exScoreStr = string.format("%.2f", exScore).."%"
 
-        local scoreStr = string.format("%.2f", score).."%"
-        local exScoreStr = string.format("%.2f", exScore).."%"
-
-        lines[#lines+1] = "    "..scoreStr.." - "..exScoreStr.." EX"
-        break
+          lines[#lines+1] = "    "..exScoreStr.." EX"
+          break
+        end
       end
     end
-
-    -- Add a new line between players.
-    lines[#lines+1] = ""
   end
 
   if data.songInfo ~= nil then
@@ -580,6 +576,9 @@ CreateOnlineHandler = function()
             return
           end
 
+          -- We're connected and in a lobby, so show the panel.
+          self:GetChild("Display"):visible(true)
+
           -- Lock input while syncing arrival on key screens.
           if syncLockScreens[screenName] then
             isWaiting = true
@@ -730,7 +729,21 @@ CreateOnlineHandler = function()
 
           -- If we're on a different screen, we'll just retain the last position.
           if screenName == "ScreenSelectMusic" then
-            self:xy(LEFT, _screen.cy)
+            -- Cover the banner entirely: match its position and dimensions
+            -- exactly (see "ScreenSelectMusic overlay/banner.lua").
+            local bannerWidth = 418
+            local bannerHeight = 164
+            local bannerCenterX, bannerCenterY, bannerZoom
+            if IsUsingWideScreen() then
+              bannerCenterX, bannerCenterY, bannerZoom = _screen.cx - 170, 96, 0.7655
+            else
+              bannerCenterX, bannerCenterY, bannerZoom = _screen.cx - 166, 96, 0.75
+            end
+
+            width = bannerWidth * bannerZoom
+            height = bannerHeight * bannerZoom
+
+            self:xy(bannerCenterX, bannerCenterY)
             bg:zoomto(width, height)
           elseif screenName == "ScreenEvaluationStage" or screenName == Branch.GameplayScreen() then
             local p1Joined = GAMESTATE:IsSideJoined("PlayerNumber_P1")
@@ -748,7 +761,7 @@ CreateOnlineHandler = function()
             end
           end
 
-          self:GetChild("Text"):playcommand("Resize", {width=width, height=height, text=params.text})
+          self:GetChild("Text"):playcommand("Resize", {width=width, height=height, text=params.text, screenName=screenName})
         end,
 
         Def.Quad{
@@ -765,15 +778,23 @@ CreateOnlineHandler = function()
             self:diffuse(Color.Yellow)
           end,
           ResizeCommand=function(self, params)
+            local leftMargin = 8
+            if params.screenName == "ScreenSelectMusic" then
+              self:horizalign(left)
+              self:x(-params.width / 2 + leftMargin)
+            else
+              self:horizalign(center)
+              self:x(0)
+            end
             self:settext(params.text)
             DiffuseEmojis(self)
             -- We don't want text to be cut off.
-            -- Incrementally adjust the zoom while checking the width until it fits.
+            -- Incrementally adjust the zoom while checking the width and height until it fits.
             -- Not the prettiest solution but it works.
             for zoomVal=1.0, 0.1, -0.05 do
               self:zoom(zoomVal)
               self:settext(params.text)
-              if self:GetWidth() * zoomVal <= params.width then
+              if self:GetWidth() * zoomVal <= params.width and self:GetHeight() * zoomVal <= params.height then
                 break
               end
             end

--- a/Scripts/SL-OnlineHelpers.lua
+++ b/Scripts/SL-OnlineHelpers.lua
@@ -35,6 +35,13 @@ local knownDisconnectScreens = {
   ["ScreenOptionsService"] = true,
 }
 
+-- The overlay never shows on any of the three Player Options screens.
+local noOverlayScreens = {
+  ["ScreenPlayerOptions"] = true,
+  ["ScreenPlayerOptions2"] = true,
+  ["ScreenPlayerOptions3"] = true,
+}
+
 -- How long to wait before displaying the state update.
 -- Since many updates may come together in a short time, we don't need to
 -- display them all immediately. Instead, we can wait a short time and then
@@ -352,33 +359,65 @@ local DisplayLobbyState = function(data, actor)
       end
     end
   end
-  for _, player in ipairs(updatedData.players) do
+
+  -- If we're in versus mode and the only two players in the lobby are our
+  -- own two local sides (i.e. nobody else from another machine has joined),
+  -- hide the overlay entirely -- there's nothing another machine needs to
+  -- sync with us on. As soon as a third player (from another machine) joins,
+  -- the normal display logic below takes back over.
+  local stylename = GAMESTATE:GetCurrentStyle():GetName()
+  local isSoloVersus = stylename == "versus" and #updatedData.players == 2
+  -- None of the Player Options screens show the overlay.
+  local hideOverlay = noOverlayScreens[screenName] or false
+  if isSoloVersus then
+    if screenName == "ScreenSelectMusic" or screenName == "ScreenEvaluationStage" then
+      hideOverlay = true
+    elseif screenName == Branch.GameplayScreen() then
+      -- Only hide once gameplay has actually begun (i.e. we're done waiting
+      -- to sync/ready up); keep showing the ready-up prompt until then.
+      hideOverlay = not isWaiting
+    end
+  end
+
+  for i, player in ipairs(updatedData.players) do
     local displayedScreen = player.screenName ~= "NoScreen" and player.screenName:gsub("Screen", "") or "Transitioning"
     local readyText = ""
     if screenName == Branch.GameplayScreen() and not updatedData.aux.allPlayersReady then
       readyText =" ["..(player.ready and "✔" or "❌").."]"
     end
 
+    -- Number the players on ScreenEvaluationStage, and on ScreenGameplay once
+    -- the notes have actually started moving (i.e. we're no longer waiting
+    -- to sync/ready up).
+    local showNumbering = screenName == "ScreenEvaluationStage"
+      or (screenName == Branch.GameplayScreen() and not isWaiting)
+
     -- Only display the screen name of the players that are on a different
     -- screen than we are.
-    local playerAndScreen = player.profileName..readyText
+    local playerAndScreen = (showNumbering and (i..'. ') or "")..player.profileName..readyText
+
+    -- Don't show the EX score for a player still on the gameplay screen
+    -- waiting to sync/ready up -- it'd just be showing the 0.00% initial value.
+    local stillWaitingForGameplayToStart = isWaiting and player.screenName == Branch.GameplayScreen()
+
+    if screenName ~= "ScreenSelectMusic" and not stillWaitingForGameplayToStart then
+      for scoreScreen in ivalues(scoreScreens) do
+        if player.screenName == scoreScreen then
+          -- Display the EX score in parentheses next to the player name.
+          local exScore = (player.exScore ~= nil and player.exScore) or 0
+          local exScoreStr = string.format("%.2f", exScore).."%"
+
+          playerAndScreen = playerAndScreen.." ("..exScoreStr..")"
+          break
+        end
+      end
+    end
+
     if screenName ~= player.screenName then
       playerAndScreen = playerAndScreen.." - in "..displayedScreen
     end
 
     lines[#lines+1] = playerAndScreen
-    if screenName ~= "ScreenSelectMusic" then
-      for scoreScreen in ivalues(scoreScreens) do
-        if player.screenName == scoreScreen then
-          -- Display the EX score only.
-          local exScore = (player.exScore ~= nil and player.exScore) or 0
-          local exScoreStr = string.format("%.2f", exScore).."%"
-
-          lines[#lines+1] = "    "..exScoreStr.." EX"
-          break
-        end
-      end
-    end
   end
 
   if data.songInfo ~= nil then
@@ -424,7 +463,7 @@ local DisplayLobbyState = function(data, actor)
 
   -- This gets cleared out by the server when every player has arrived at the song selection screen.
   songSelected = (data.songInfo ~= nil)
-  actor:GetChild("Display"):playcommand("UpdateText", {text=table.concat(lines, "\n")})
+  actor:GetChild("Display"):playcommand("UpdateText", {text=table.concat(lines, "\n"), hideOverlay=hideOverlay})
 end
 
 local HandleResponse = function(response, actor)
@@ -576,8 +615,9 @@ CreateOnlineHandler = function()
             return
           end
 
-          -- We're connected and in a lobby, so show the panel.
-          self:GetChild("Display"):visible(true)
+          -- We're connected and in a lobby, so show the panel (except on
+          -- the Player Options screens, which never show it).
+          self:GetChild("Display"):visible(not noOverlayScreens[screenName])
 
           -- Lock input while syncing arrival on key screens.
           if syncLockScreens[screenName] then
@@ -715,10 +755,13 @@ CreateOnlineHandler = function()
           self:xy(LEFT, _screen.cy)
         end,
         UpdateTextCommand=function(self, params)
+          self:visible(not params.hideOverlay)
+
           local screen = SCREENMAN:GetTopScreen()
           local screenName = screen and screen:GetName() or "NoScreen"
 
           local bg = self:GetChild("Background")
+          bg:visible(true)
           local width = 200
           local height = SCREEN_HEIGHT
 
@@ -745,23 +788,128 @@ CreateOnlineHandler = function()
 
             self:xy(bannerCenterX, bannerCenterY)
             bg:zoomto(width, height)
-          elseif screenName == "ScreenEvaluationStage" or screenName == Branch.GameplayScreen() then
+          elseif screenName == "ScreenEvaluationStage" then
+            -- Cover the banner entirely: match its position and dimensions
+            -- exactly (see "ScreenEvaluation common/Shared/TitleAndBanner.lua").
+            -- Unlike the ScreenSelectMusic banner, this one isn't
+            -- widescreen-dependent, but its y-position does shift for Casual mode.
+            local bannerWidth = 418
+            local bannerHeight = 164
+            local bannerZoom = 0.7
+            local yOffset = SL.Global.GameMode == "Casual" and 50 or 46
+            local bannerCenterX = _screen.cx
+            local bannerCenterY = yOffset + 66
+
+            width = bannerWidth * bannerZoom
+            height = bannerHeight * bannerZoom
+
+            self:xy(bannerCenterX, bannerCenterY)
+            bg:zoomto(width, height)
+          elseif screenName == Branch.GameplayScreen() then
             local p1Joined = GAMESTATE:IsSideJoined("PlayerNumber_P1")
             local p2Joined = GAMESTATE:IsSideJoined("PlayerNumber_P2")
 
+            local IsUltraWide = (GetScreenAspectRatio() > 21/9)
+            local stylename = GAMESTATE:GetCurrentStyle():GetName()
+            local centerY = _screen.cy
+            local overrideCenterX = nil
+
+            if stylename == "single" or stylename == "versus" then
+              bg:visible(false)
+            end
+
+            if stylename == "versus" and not IsUltraWide then
+              -- Versus mode (at standard aspect ratios) has no side pane at
+              -- all in StepStatistics/default.lua -- the judgment counters
+              -- just sit in a narrow column next to each notefield. Use a
+              -- narrow fixed width to match that footprint instead.
+              width = 150
+
+              -- Move our top edge down to meet the top edge of the small
+              -- banner shown here (see "ScreenGameplay underlay/Shared/VersusStepStatistics.lua"),
+              -- keeping our bottom edge where it was.
+              local versusBannerHeight = 164 * 0.3
+              local versusBannerTop = (_screen.cy + 70) - versusBannerHeight / 2
+
+              height = SCREEN_HEIGHT - versusBannerTop
+              centerY = versusBannerTop + height / 2
+            else
+              -- Match the width allotted to the judgment counters' side pane
+              -- (see "ScreenGameplay underlay/PerPlayer/StepStatistics/default.lua").
+              -- The notefield is never centered in this setup, so we don't need
+              -- to handle that branch of default.lua's sidepane_width logic.
+              local enabledPlayer = GAMESTATE:GetEnabledPlayers()[1]
+
+              width = _screen.w / 2
+              if IsUltraWide and #GAMESTATE:GetHumanPlayers() > 1 then
+                width = _screen.w / 5
+              end
+
+              if stylename == "single" then
+                -- Align our bottom edge with the top edge of the Step
+                -- Statistics density graph (see "ScreenGameplay underlay/
+                -- PerPlayer/StepStatistics/DensityGraph.lua"), and our top
+                -- edge with the bottom edge of the Holds/Mines/Rolls counts
+                -- (see "ScreenGameplay underlay/PerPlayer/StepStatistics/HoldsMinesRolls.lua").
+                -- HoldsMinesRolls has no explicit height, so we approximate
+                -- its bottom using its 3 rows of row_height=28, starting at
+                -- y=-140 from the StepStatsPane's origin (_screen.cy + header_height).
+                local headerHeight = 80
+                local densityGraphTop = _screen.cy + headerHeight + 55
+                local holdsMinesRollsBottom = (_screen.cy + headerHeight) - 140 + (3 * 28)
+
+                -- Peak NPS text (also in DensityGraph.lua) sits just above the
+                -- density graph's own top edge. It has no fixed height, so we
+                -- approximate a single line at zoom(0.9) using Common Normal's
+                -- underlying font metrics (Top=4, Baseline=19 -> ~14px tall),
+                -- giving roughly 1.5*textHeight+2 of extra clearance to pull
+                -- our bottom edge up by.
+                local peakNPSClearance = 23
+
+                height = (densityGraphTop - peakNPSClearance) - holdsMinesRollsBottom
+                centerY = holdsMinesRollsBottom + height / 2
+
+                -- Align both our inner and outer edges with the inner and
+                -- outer edges of the Step Statistics banner (see
+                -- "ScreenGameplay underlay/PerPlayer/StepStatistics/Banner.lua"),
+                -- rather than anchoring to the screen edge or notefield.
+                -- The notefield is never centered in this setup, so
+                -- default.lua's sidepane_pos_x always uses its fixed-fraction
+                -- fallback, Banner.lua's offset is always 70 (not 72), and
+                -- "BannerAndData"'s extra zoom is never applied (stays at 1).
+                local isP1 = enabledPlayer == PLAYER_1
+                local sidepanePosX = _screen.w * (isP1 and 0.75 or 0.25)
+                local bannerOffset = 70
+
+                local bannerCenterX = sidepanePosX + (isP1 and bannerOffset or -bannerOffset)
+                local bannerWidth = 418 * 0.4
+
+                width = bannerWidth
+                overrideCenterX = bannerCenterX
+              end
+            end
+
+            local left = width / 2
+            local right = SCREEN_WIDTH - width / 2
+
+            if overrideCenterX then
+              left = overrideCenterX
+              right = overrideCenterX
+            end
+
             if p1Joined and p2Joined then
-              self:xy(CENTER, _screen.cy)
+              self:xy(CENTER, centerY)
               bg:zoomto(width, height)
             elseif p1Joined then
-              self:xy(RIGHT, _screen.cy)
+              self:xy(right, centerY)
               bg:zoomto(width, height)
             elseif p2Joined then
-              self:xy(LEFT, _screen.cy)
+              self:xy(left, centerY)
               bg:zoomto(width, height)
             end
           end
 
-          self:GetChild("Text"):playcommand("Resize", {width=width, height=height, text=params.text, screenName=screenName})
+          self:GetChild("Text"):playcommand("Resize", {width=width, height=height, text=params.text})
         end,
 
         Def.Quad{
@@ -778,14 +926,6 @@ CreateOnlineHandler = function()
             self:diffuse(Color.Yellow)
           end,
           ResizeCommand=function(self, params)
-            local leftMargin = 8
-            if params.screenName == "ScreenSelectMusic" then
-              self:horizalign(left)
-              self:x(-params.width / 2 + leftMargin)
-            else
-              self:horizalign(center)
-              self:x(0)
-            end
             self:settext(params.text)
             DiffuseEmojis(self)
             -- We don't want text to be cut off.

--- a/Scripts/SL-OnlineHelpers.lua
+++ b/Scripts/SL-OnlineHelpers.lua
@@ -535,7 +535,6 @@ CreateOnlineHandler = function()
                 self.inLobby = false
                 self.lobbyCode = nil
                 self.errorMsg = nil
-                self:GetChild("Display"):visible(true)
               elseif msgType == "Message" then
                 local response = JsonDecode(msg.data)
                 HandleResponse(response, self)


### PR DESCRIPTION
## Summary (Written by Claude)

Overhauls the online-lobby overlay panel's sizing, positioning, and content across `ScreenSelectMusic`, `ScreenGameplay`, `ScreenEvaluationStage`, and the three Player Options screens, and adds the lobby code to the Player Options header.

## Changes

### `Scripts/SL-OnlineHelpers.lua`

- **Player Options screens never show the overlay** — new `noOverlayScreens` lookup table (`ScreenPlayerOptions`, `ScreenPlayerOptions2`, `ScreenPlayerOptions3`), checked in both `DisplayLobbyState`'s `hideOverlay` calculation and `ScreenChangedMessageCommand`'s immediate visibility toggle.
- **Solo-versus auto-hide** — when in versus style with exactly 2 players in the lobby (i.e. no other machine has joined), the overlay hides entirely on `ScreenSelectMusic`/`ScreenEvaluationStage`, and on `ScreenGameplay` once gameplay has actually begun (`not isWaiting`). This `hideOverlay` flag flows through the `UpdateText` playcommand into `UpdateTextCommand`, applied via `self:visible(not params.hideOverlay)`.
- **Player list formatting**:
  - Numbering restored, but only on `ScreenEvaluationStage` (always) and `ScreenGameplay` (once gameplay has started).
  - EX score now appended in parentheses directly on the player's line (`"Name (98.00%)"`) instead of a separate `"... EX"` line.
  - EX score suppressed while a player is still waiting to ready up on the gameplay screen.
- **Per-screen box geometry overhaul**:
  - `ScreenEvaluationStage` gets its own branch (previously shared with Gameplay) that covers its banner exactly (`TitleAndBanner.lua`'s position/size, including the Casual-mode y-offset).
  - `ScreenGameplay` computes real layout-matched geometry per style:
    - Versus mode: narrow fixed width (150), top edge aligned to the small versus banner's top edge.
    - Single mode: bottom edge aligned to the density graph's top edge (minus ~23px clearance for the Peak NPS text), top edge aligned to the bottom of the Holds/Mines/Rolls counts, and both left/right edges aligned to the Step Statistics banner's own footprint (replacing the old screen-edge-anchored width).
  - Background quad (`bg`) explicitly hidden for `single`/`versus` styles on Gameplay, reset visible by default otherwise.
- Removed the earlier `ScreenSelectMusic`-only left-align/margin logic on the `Text` actor — text is centered everywhere again; dropped the now-unused `screenName` param from the `Resize` playcommand.

### `BGAnimations/ScreenPlayerOptions common.lua`

Added a new actor (shared by all three Player Options screens, since screens 2 and 3 load this file directly as their overlay) that listens for lobby state changes and rebroadcasts `SetHeaderText` with the lobby code appended, e.g. `"Select Modifiers (ABCD)"`, falling back to the plain themed header text when not in a lobby.

### `BGAnimations/ScreenPlayerOptions overlay/default.lua`

Comment-only change noting that the lobby-code header logic now lives in `ScreenPlayerOptions common.lua` rather than here.

## Screenshots
Online lobby overlay covers the banner.
<img width="1924" height="1126" alt="image" src="https://github.com/user-attachments/assets/f2a82181-c54a-4adf-af6d-57f73303c123" />

If connected to an online lobby the lobby code is shown next to "Select Modifiers" in parenthesis and does not show the overlay.
<img width="1924" height="1126" alt="image" src="https://github.com/user-attachments/assets/eb8755a4-08ae-44cb-8101-461fb83f29be" />
<img width="1924" height="1126" alt="image" src="https://github.com/user-attachments/assets/58e5ad41-c617-4c0b-af44-6f925e3b5a37" />
<img width="1924" height="1126" alt="image" src="https://github.com/user-attachments/assets/7411d53f-5b58-41d3-bd99-62484d474f9f" />

Move the placement on Versus mode when playing with others in a lobby.
<img width="1924" height="1126" alt="image" src="https://github.com/user-attachments/assets/28def45a-444c-47fb-a20a-8b502a0a3643" />

Numbering re-appears when gameplay has begun. 
<img width="1924" height="1126" alt="image" src="https://github.com/user-attachments/assets/a7abe335-91df-48e0-949b-335d39b96437" />

Overlay in ScreenEvaluation displays over the banner.
<img width="1924" height="1126" alt="image" src="https://github.com/user-attachments/assets/840aff00-5239-4c2e-98cb-8c225a103fb7" />

In "Solo Versus" mode (the only two players in the lobby are the two players on the machine) the lobby code still displays on the top-right but the overlay is hidden.
<img width="1924" height="1126" alt="image" src="https://github.com/user-attachments/assets/d4383dfe-1844-4d79-99d9-d6bff2984f8d" />

Overlay adjusts for P1/P2 when not in versus mode.
<img width="1924" height="1126" alt="image" src="https://github.com/user-attachments/assets/314d68a5-7f8b-46a8-861a-52ee44d96c58" />
<img width="1924" height="1126" alt="image" src="https://github.com/user-attachments/assets/ea039eeb-6fe8-4834-8563-931b30f2fc11" />

## Test plan

- [x] Verify overlay hides on all three Player Options screens
- [x] Verify lobby code appears in the Player Options header when connected.
- [x] Verify overlay hides in solo versus (2 local players, no remote) on select music/gameplay/evaluation
- [x] Verify overlay geometry on `ScreenGameplay` in single mode aligns with density graph / holds-mines-rolls / banner as expected
- [x] Verify overlay geometry on `ScreenGameplay` in versus mode aligns with the versus banner
- [x] Verify `ScreenEvaluationStage` overlay covers its banner correctly

## TODO

In solo versus mode the players still have to ready up, should they auto-ready instead?
EDIT: Resolved in https://github.com/vlnguyen/Simply-Love-SM5/pull/8
<img width="1924" height="1126" alt="image" src="https://github.com/user-attachments/assets/ebf99156-82c8-4ac8-b311-bcc19498435c" />
