### PR TITLE
Dim EX score in Tournament EX mode in online lobbies

### DIFF
--- a/BGAnimations/ScreenGameplay overlay/WhoIsCurrentlyWinning.lua
+++ b/BGAnimations/ScreenGameplay overlay/WhoIsCurrentlyWinning.lua
@@ -1,12 +1,22 @@
 -- If both players are joined, change the opacity of their score BitmapText actors to
 -- visually indicate who is winning at a given moment during gameplay.
+--
+-- During a Tournament Mode (EX scoring) event while connected to an online lobby,
+-- standing is instead judged against the whole lobby rather than just a local
+-- opponent -- there might only be one local player racing remote opponents. (Solo
+-- versus -- see IsSoloVersus() -- still falls back to the local-only behavior, since
+-- the "whole lobby" there is just the two local players anyway.)
 ------------------------------------------------------------
 
--- if there is only one player, don't bother
-if #GAMESTATE:GetHumanPlayers() < 2 then return end
+local handler = GetOnlineHandlerInstance()
+local UseLobbyStandings = handler and handler.inLobby and IsTournamentModeEX() and not IsSoloVersus()
 
--- if displaying different scoring mechanisms, don't bother.
-if SL["P1"].ActiveModifiers.ShowExScore ~= SL["P2"].ActiveModifiers.ShowExScore then return end
+-- Outside of that specific lobby scenario, there's no one to compare against
+-- unless both local players are joined and using the same scoring mechanism.
+if not UseLobbyStandings then
+	if #GAMESTATE:GetHumanPlayers() < 2 then return end
+	if SL["P1"].ActiveModifiers.ShowExScore ~= SL["P2"].ActiveModifiers.ShowExScore then return end
+end
 
 local p1_score, p2_score
 local p1_dp = 0
@@ -28,6 +38,9 @@ return Def.Actor{
 		p2_score = underlay:GetChild("P2Score")
 	end,
 	JudgmentMessageCommand=function(self, params)
+		-- Tournament Mode + EX scoring always reports via ExCountsChanged instead.
+		if UseLobbyStandings then return end
+
 		if not IsEX then
 			-- calculate the percentage DP manually rather than use GetPercentDancePoints.
 			-- That function rounds to the nearest .01%, which is inaccurate on long songs.
@@ -40,6 +53,18 @@ return Def.Actor{
 		end
 	end,
 	ExCountsChangedMessageCommand=function(self, params)
+		if UseLobbyStandings then
+			-- Tournament Mode + EX scoring forces everyone's ShowExScore to true,
+			-- so this is always the EX score, regardless of join status.
+			if params.Player == PLAYER_1 then
+				p1_dp = params.ExScore
+			elseif params.Player == PLAYER_2 then
+				p2_dp = params.ExScore
+			end
+			self:queuecommand("Winning")
+			return
+		end
+
 		if IsEX then
 			if params.Player == PLAYER_1 then
 				p1_dp = params.ExScore
@@ -49,7 +74,35 @@ return Def.Actor{
 			self:queuecommand("Winning")
 		end
 	end,
+	OnlineLobbyStateMessageCommand=function(self)
+		-- Remote players' scores update via the lobby server, not local
+		-- Judgment/ExCountsChanged messages, so re-check on every lobby update too.
+		self:queuecommand("Winning")
+	end,
 	WinningCommand=function(self)
+		-- Check fresh each time (rather than the load-time snapshot) so a
+		-- mid-song disconnect gracefully falls back to local-only comparison.
+		local handler = GetOnlineHandlerInstance()
+		local useLobbyStandingsNow = handler and handler.inLobby and IsTournamentModeEX() and not IsSoloVersus()
+
+		if useLobbyStandingsNow then
+			-- Judge each local player against the whole lobby instead of just
+			-- each other -- there might only be one local player here. Pull
+			-- "my score" from the lobby roster too (not local judgment
+			-- tracking), so both sides of the comparison come from the same
+			-- synced snapshot. Always EX score in this mode.
+			local best = GetBestLobbyScore(true)
+			if GAMESTATE:IsSideJoined(PLAYER_1) then
+				local myLobbyScore = GetLobbyScoreForPlayer(PLAYER_1, true)
+				try_diffusealpha(p1_score, (not best or not myLobbyScore or myLobbyScore >= best) and 1 or 0.65)
+			end
+			if GAMESTATE:IsSideJoined(PLAYER_2) then
+				local myLobbyScore = GetLobbyScoreForPlayer(PLAYER_2, true)
+				try_diffusealpha(p2_score, (not best or not myLobbyScore or myLobbyScore >= best) and 1 or 0.65)
+			end
+			return
+		end
+
 		if p1_dp == p2_dp then
 			try_diffusealpha(p1_score, 1)
 			try_diffusealpha(p2_score, 1)
@@ -60,5 +113,5 @@ return Def.Actor{
 			try_diffusealpha(p1_score, 0.65)
 			try_diffusealpha(p2_score, 1)
 		end
-	end
+	end,
 }

--- a/BGAnimations/ScreenGameplay underlay/PerPlayer/StepStatistics/TapNoteJudgments.lua
+++ b/BGAnimations/ScreenGameplay underlay/PerPlayer/StepStatistics/TapNoteJudgments.lua
@@ -10,7 +10,11 @@ local StepsOrTrail = (GAMESTATE:IsCourseMode() and GAMESTATE:GetCurrentTrail(pla
 local total_tapnotes = StepsOrTrail:GetRadarValues(player):GetValue( "RadarCategory_Notes" )
 
 -- Only add this in ITG mode.
-local ShowFaPlusWindow = SL[pn].ActiveModifiers.ShowFaPlusWindow and SL.Global.GameMode=="ITG"
+-- Always show it in Tournament Mode when scoring by EX, regardless of the
+-- player's own ShowFaPlusWindow preference (that toggle only controls the
+-- in-gameplay flash window; step stats should still reflect W0 counts).
+local ForceFaPlusWindow = ThemePrefs.Get("EnableTournamentMode") and ThemePrefs.Get("ScoringSystem") == "EX"
+local ShowFaPlusWindow = (SL[pn].ActiveModifiers.ShowFaPlusWindow or ForceFaPlusWindow) and SL.Global.GameMode=="ITG"
 
 -- determine how many digits are needed to express the number of notes in base-10
 local digits = (math.floor(math.log10(total_tapnotes)) + 1)

--- a/BGAnimations/ScreenGameplay underlay/PerPlayer/StepStatistics/default.lua
+++ b/BGAnimations/ScreenGameplay underlay/PerPlayer/StepStatistics/default.lua
@@ -9,7 +9,13 @@ local NoteFieldIsCentered = (GetNotefieldX(player) == _screen.cx)
 
 local stylename = GAMESTATE:GetCurrentStyle():GetName()
 
-if SL[pn].ActiveModifiers.DataVisualizations ~= "Step Statistics" then return end
+-- Tournament Mode removes the DataVisualizations option row entirely (see
+-- metrics.ini), so a player who never manually picked "Step Statistics"
+-- before Tournament Mode kicked in has no way to satisfy this otherwise --
+-- StepStats=="Show" (the default) should force it on regardless, matching
+-- the same bypass VersusStepStatistics.lua already uses.
+local ForceStepStats = ThemePrefs.Get("EnableTournamentMode") and ThemePrefs.Get("StepStats") == "Show"
+if SL[pn].ActiveModifiers.DataVisualizations ~= "Step Statistics" and not ForceStepStats then return end
 
 if (not IsUltraWide and stylename == "versus")
 	or (not ThemePrefs.Get("EnableTournamentMode") and

--- a/BGAnimations/ScreenGameplay underlay/Shared/VersusStepStatistics.lua
+++ b/BGAnimations/ScreenGameplay underlay/Shared/VersusStepStatistics.lua
@@ -2,17 +2,30 @@ local Players = GAMESTATE:GetHumanPlayers()
 local IsUltraWide = (GetScreenAspectRatio() > 21/9)
 local FilterAlpha = BackgroundFilterValues()
 
+local OnlineHandler = GetOnlineHandlerInstance()
+-- During a Tournament Mode (EX scoring) event while connected to an online
+-- lobby, this pane can apply even in single style, since there might only be
+-- one local player racing remote opponents. Solo versus still falls back to
+-- the original versus-only behavior, since the "whole lobby" there is just
+-- the two local players anyway.
+local UseLobbyStandings = OnlineHandler and OnlineHandler.inLobby and IsTournamentModeEX() and not IsSoloVersus()
+
 local ShouldDisplayStatsForPlayer = function(player)
     local pn = ToEnumShortString(player)
     return (SL[pn].ActiveModifiers.DataVisualizations == "Step Statistics" or
-            ThemePrefs.Get("EnableTournamentMode") and ThemePrefs.Get("StepStats") == "Show")
+            (ThemePrefs.Get("EnableTournamentMode") and ThemePrefs.Get("StepStats") == "Show") or
+            UseLobbyStandings)
 end
 
 local ShouldDisplayStats = function()
-    -- Only use this in Versus + Widescreen.
-    if GAMESTATE:GetCurrentStyle():GetName() ~= "versus" or not IsUsingWideScreen() then
+    -- Outside of that specific lobby scenario, this is strictly a versus-mode
+    -- feature (a second step-stats readout for the versus layout, since the
+    -- normal single-player StepStatsPane doesn't support versus).
+    if not UseLobbyStandings and GAMESTATE:GetCurrentStyle():GetName() ~= "versus" then
         return false
     end
+
+    if not IsUsingWideScreen() then return false end
 
     -- Ultrawide versus is already supported natively.
     if IsUltraWide then return false end
@@ -59,7 +72,7 @@ if ShouldDisplayStats() then
 end
 
 for player in ivalues(Players) do
-    if ShouldDisplayStatsForPlayer(player) and #Players > 1 then
+    if ShouldDisplayStatsForPlayer(player) and (#Players > 1 or UseLobbyStandings) then
         -- No need to reimplement the wheel here. Just use the existing actor and modify it for our use case.
         local judgments = LoadActor("../PerPlayer/StepStatistics/TapNoteJudgments.lua", {player, false})
         judgments.InitCommand = function(self)    
@@ -83,16 +96,16 @@ for player in ivalues(Players) do
 
         af[#af+1] = judgments
 
-        -- Add a score to Step Stats if it's hidden by the NPS graph or we're in Tournament Mode.
-        if SL[ToEnumShortString(player)].ActiveModifiers.NPSGraphAtTop or ThemePrefs.Get("EnableTournamentMode") then
+        -- Add a score to Step Stats if it's hidden by the NPS graph, we're in
+        -- Tournament Mode, or we're using lobby-wide standings (there might be
+        -- a remote opponent to compare against with no local versus partner).
+        if SL[ToEnumShortString(player)].ActiveModifiers.NPSGraphAtTop or ThemePrefs.Get("EnableTournamentMode") or UseLobbyStandings then
             local pn = ToEnumShortString(player)
             local IsEX = SL[pn].ActiveModifiers.ShowExScore
             local otherPlayer = OtherPlayer[player]
 
             -- Mirror "ScreenGameplay overlay/WhoIsCurrentlyWinning.lua": dim
-            -- whichever player is currently behind. Only bother comparing if
-            -- both players are using the same scoring mechanism.
-            local scoringMechanismsMatch = SL["P1"].ActiveModifiers.ShowExScore == SL["P2"].ActiveModifiers.ShowExScore
+            -- whichever player is currently behind.
             local myScore = 0
             local theirScore = 0
             local pss = STATSMAN:GetCurStageStats():GetPlayerStageStats(player)
@@ -120,7 +133,7 @@ for player in ivalues(Players) do
                         self:queuecommand("RedrawScore")
                     end
 
-                    if not IsEX and scoringMechanismsMatch and (params.Player == player or params.Player == otherPlayer) then
+                    if not IsEX and (params.Player == player or params.Player == otherPlayer) then
                         -- calculate the percentage DP manually rather than use GetPercentDancePoints.
                         -- That function rounds to the nearest .01%, which is inaccurate on long songs.
                         if params.Player == player then
@@ -148,13 +161,40 @@ for player in ivalues(Players) do
                         else
                             theirScore = params.ExScore
                         end
-
-                        if scoringMechanismsMatch then
-                            self:queuecommand("RedrawWinning")
-                        end
+                        self:queuecommand("RedrawWinning")
                     end
                 end,
+                OnlineLobbyStateMessageCommand=function(self)
+                    -- Remote players' scores update via the lobby server, not
+                    -- local Judgment/ExCountsChanged messages, so re-check on
+                    -- every lobby update too.
+                    self:queuecommand("RedrawWinning")
+                end,
                 RedrawWinningCommand=function(self)
+                    -- Check fresh each time (rather than the load-time
+                    -- snapshot) so a mid-song disconnect gracefully falls back
+                    -- to local-only comparison.
+                    local handler = GetOnlineHandlerInstance()
+                    local useLobbyStandingsNow = handler and handler.inLobby and IsTournamentModeEX() and not IsSoloVersus()
+
+                    if useLobbyStandingsNow then
+                        -- Pull "my score" from the lobby roster too (not local
+                        -- judgment tracking), so both sides of the comparison
+                        -- come from the same synced snapshot. Always EX score
+                        -- in this mode.
+                        local best = GetBestLobbyScore(true)
+                        local myLobbyScore = GetLobbyScoreForPlayer(player, true)
+                        self:diffusealpha((not best or not myLobbyScore or myLobbyScore >= best) and 1 or 0.65)
+                        return
+                    end
+
+                    -- Only compare locally if both players are using the same
+                    -- scoring mechanism.
+                    if SL["P1"].ActiveModifiers.ShowExScore ~= SL["P2"].ActiveModifiers.ShowExScore then
+                        self:diffusealpha(1)
+                        return
+                    end
+
                     if myScore >= theirScore then
                         self:diffusealpha(1)
                     else

--- a/BGAnimations/ScreenGameplay underlay/Shared/VersusStepStatistics.lua
+++ b/BGAnimations/ScreenGameplay underlay/Shared/VersusStepStatistics.lua
@@ -2,30 +2,26 @@ local Players = GAMESTATE:GetHumanPlayers()
 local IsUltraWide = (GetScreenAspectRatio() > 21/9)
 local FilterAlpha = BackgroundFilterValues()
 
+-- This pane's whole purpose is a versus-specific layout (split-screen
+-- background, "other side" positioning, etc.) that the normal single-player
+-- StepStatsPane doesn't support -- so which layout renders must depend only
+-- on the local style/player count, never on the lobby's total player count.
+-- UseLobbyStandings (below) only affects the score-text's own visibility and
+-- dimming math further down, not whether this pane exists at all.
 local OnlineHandler = GetOnlineHandlerInstance()
--- During a Tournament Mode (EX scoring) event while connected to an online
--- lobby, this pane can apply even in single style, since there might only be
--- one local player racing remote opponents. Solo versus still falls back to
--- the original versus-only behavior, since the "whole lobby" there is just
--- the two local players anyway.
 local UseLobbyStandings = OnlineHandler and OnlineHandler.inLobby and IsTournamentModeEX() and not IsSoloVersus()
 
 local ShouldDisplayStatsForPlayer = function(player)
     local pn = ToEnumShortString(player)
     return (SL[pn].ActiveModifiers.DataVisualizations == "Step Statistics" or
-            (ThemePrefs.Get("EnableTournamentMode") and ThemePrefs.Get("StepStats") == "Show") or
-            UseLobbyStandings)
+            (ThemePrefs.Get("EnableTournamentMode") and ThemePrefs.Get("StepStats") == "Show"))
 end
 
 local ShouldDisplayStats = function()
-    -- Outside of that specific lobby scenario, this is strictly a versus-mode
-    -- feature (a second step-stats readout for the versus layout, since the
-    -- normal single-player StepStatsPane doesn't support versus).
-    if not UseLobbyStandings and GAMESTATE:GetCurrentStyle():GetName() ~= "versus" then
+    -- Only use this in Versus + Widescreen.
+    if GAMESTATE:GetCurrentStyle():GetName() ~= "versus" or not IsUsingWideScreen() then
         return false
     end
-
-    if not IsUsingWideScreen() then return false end
 
     -- Ultrawide versus is already supported natively.
     if IsUltraWide then return false end
@@ -72,7 +68,7 @@ if ShouldDisplayStats() then
 end
 
 for player in ivalues(Players) do
-    if ShouldDisplayStatsForPlayer(player) and (#Players > 1 or UseLobbyStandings) then
+    if ShouldDisplayStatsForPlayer(player) and GAMESTATE:GetNumSidesJoined() > 1 then
         -- No need to reimplement the wheel here. Just use the existing actor and modify it for our use case.
         local judgments = LoadActor("../PerPlayer/StepStatistics/TapNoteJudgments.lua", {player, false})
         judgments.InitCommand = function(self)    

--- a/BGAnimations/ScreenGameplay underlay/Shared/VersusStepStatistics.lua
+++ b/BGAnimations/ScreenGameplay underlay/Shared/VersusStepStatistics.lua
@@ -87,6 +87,16 @@ for player in ivalues(Players) do
         if SL[ToEnumShortString(player)].ActiveModifiers.NPSGraphAtTop or ThemePrefs.Get("EnableTournamentMode") then
             local pn = ToEnumShortString(player)
             local IsEX = SL[pn].ActiveModifiers.ShowExScore
+            local otherPlayer = OtherPlayer[player]
+
+            -- Mirror "ScreenGameplay overlay/WhoIsCurrentlyWinning.lua": dim
+            -- whichever player is currently behind. Only bother comparing if
+            -- both players are using the same scoring mechanism.
+            local scoringMechanismsMatch = SL["P1"].ActiveModifiers.ShowExScore == SL["P2"].ActiveModifiers.ShowExScore
+            local myScore = 0
+            local theirScore = 0
+            local pss = STATSMAN:GetCurStageStats():GetPlayerStageStats(player)
+            local other_pss = STATSMAN:GetCurStageStats():GetPlayerStageStats(otherPlayer)
 
             af[#af+1] = LoadFont("Wendy/_wendy monospace numbers")..{
                 Text="0.00",
@@ -106,22 +116,49 @@ for player in ivalues(Players) do
                     end
                 end,
                 JudgmentMessageCommand=function(self, params)
-                    if params.Player ~= player then return end
-                    self:queuecommand("RedrawScore")
+                    if params.Player == player then
+                        self:queuecommand("RedrawScore")
+                    end
+
+                    if not IsEX and scoringMechanismsMatch and (params.Player == player or params.Player == otherPlayer) then
+                        -- calculate the percentage DP manually rather than use GetPercentDancePoints.
+                        -- That function rounds to the nearest .01%, which is inaccurate on long songs.
+                        if params.Player == player then
+                            myScore = pss:GetActualDancePoints() / pss:GetPossibleDancePoints()
+                        else
+                            theirScore = other_pss:GetActualDancePoints() / other_pss:GetPossibleDancePoints()
+                        end
+                        self:queuecommand("RedrawWinning")
+                    end
                 end,
                 RedrawScoreCommand=function(self)
                     if not IsEX then
-                        local pss = STATSMAN:GetCurStageStats():GetPlayerStageStats(player)
                         local dance_points = pss:GetPercentDancePoints()
                         local percent = FormatPercentScore( dance_points ):sub(1,-2)
                         self:settext(percent)
                     end
                 end,
                 ExCountsChangedMessageCommand=function(self, params)
-                    if params.Player ~= player then return end
-            
+                    if params.Player ~= player and params.Player ~= otherPlayer then return end
+
                     if IsEX then
-                        self:settext(("%.02f"):format(params.ExScore))
+                        if params.Player == player then
+                            self:settext(("%.02f"):format(params.ExScore))
+                            myScore = params.ExScore
+                        else
+                            theirScore = params.ExScore
+                        end
+
+                        if scoringMechanismsMatch then
+                            self:queuecommand("RedrawWinning")
+                        end
+                    end
+                end,
+                RedrawWinningCommand=function(self)
+                    if myScore >= theirScore then
+                        self:diffusealpha(1)
+                    else
+                        self:diffusealpha(0.65)
                     end
                 end,
             }

--- a/README.md
+++ b/README.md
@@ -1,131 +1,65 @@
-# Simply Love (ITGmania)
+# Simply Love (ITGmania) — Online Lobby / Tournament Fork
 
 ![Arrow Logo](https://i.imgur.com/oZmxyGo.png)
 
+This is a fork of [Simply Love](https://github.com/Simply-Love/Simply-Love-SM5), the ITGmania theme, built on top of the `itgmania-release` branch. It keeps everything from upstream Simply Love and adds a set of changes aimed at running online, lobby-based tournament events. For general information about Simply Love itself — installation, language support, aspect ratios, etc. — see the [upstream README](https://github.com/Simply-Love/Simply-Love-SM5/blob/itgmania-release/README.md).
 
-## About
-
-Simply Love is an ITGmania theme for the post-ITG community.
-
-It features a clean and simple design, offers numerous data-driven features not implemented by the ITGmania engine, and allows the current generation of ITG fans to breathe new life into the game they've known for over a two decades.
-
-Simply Love was originally designed and implemented for a previous version of StepMania (SM3.95) by hurtpiggypig.  For more information on that version of Simply Love, check here:
-https://www.youtube.com/watch?v=OtcWy5m6-CQ
+This document only covers what's different in this fork.
 
 
-## Supported Versions of ITGmania
+## Connecting to an Online Lobby is now required (optional)
 
-The current release of Simply Love is compatible with current ITGmania versions **0.8.0** or newer.
+Upstream Simply Love already has an experimental "Enable Online Lobbies" option for connecting with other players over the internet. This fork adds a second option, **Require Lobbies** (found alongside it in *System Options → GrooveStats*), which is **on by default**.
 
-For new installations we currently recommend grabbing the ITGmania + Simply Love bundle over at the
-[www.itgmania.com](https://www.itgmania.com).
-
-
-**Incompatible Versions**<br>
-❌ StepMania 5 (SM5)<br>
-❌ Forks of SM5 (e.g. *starworlds*)<br>
-❌ Older versions of StepMania (e.g. StepMania 3.9)<br>
-❌ Forks of older versions of StepMania (e.g. OpenITG, NotITG)<br>
-❌ SM5.2
+While it's enabled, a banner reading "Connect to an online lobby to play" is shown on Select Music, all three Player Options screens, Gameplay, and Evaluation until you actually join a lobby. It disappears automatically as soon as you're connected, and reappears if you disconnect. Turn the option off if you want to play normally without a lobby connection.
 
 
-## Installing Simply Love
+## Your lobby code is now shown throughout the session
 
-If you are upgrading from a previous version of Simply Love, fully delete the old Simply Love folder first.  **Do not merge the new folder into the old.**
+Once connected to a lobby, its code is now displayed in a few places it wasn't before:
 
-You can download the current Simply Love release at the [Latest Release](https://github.com/Simply-Love/Simply-Love-SM5/releases/latest) page.
+- In the top-right corner of Select Music, where the game mode name normally appears.
+- In the header of the Evaluation screen, same spot.
+- In the header of the Player Options screens (e.g. "Select Modifiers (ABCD)").
+- In place of "Event" on the stage indicator during gameplay, if you're playing in Event Mode.
 
-Full install instructions are in the [Installing Simply Love](./Other/Documentation/InstallingSimplyLove-README.md) README.
-
-
-## Language Support
-
-Simply Love has support for:
-
-  * English
-  * Deutsch
-  * Español
-  * Français
-  * Italiano
-  * 日本語
-  * Polski
-  * Português Brasileiro (incomplete, translator wanted)
-  * Русский
-
-The current language can be changed in Simply Love under *System Options*.
+This makes it easy to double check (or tell someone else) which lobby you're currently in without needing to back out to a menu.
 
 
-## Aspect Ratio Support
+## The lobby roster overlay is cleaner
 
-Simply Love is designed to be usable at resolutions as low as 640x480 but still look crisp and clean in HD, 2k, 4k, etc.  It supports many screen aspect ratios:
+The overlay listing everyone in your lobby has been condensed and cleaned up:
 
-  * <strong>16:9</strong> (common)
-  * <strong>16:10</strong> (Apple laptops, some LCD monitors)
-  * <strong>4:3</strong> (CRT arcade monitors, older TVs)
-  * <strong>21:9</strong> ("Ultrawide")
-
-The aspect ratio can be changed under *Graphics / Sound Options*.
+- Each player's current score is now shown compactly in parentheses next to their name (e.g. `1. PlayerName (91.42%)`) instead of on its own separate lines below the name.
+- A player's score is hidden until they've actually started playing their song, so you don't see a meaningless "0.00%" while they're still readying up.
+- Players are no longer numbered while everyone's still syncing up between screens — numbering (by current standing) only appears once gameplay is actually underway or during Evaluation.
+- If you're playing local versus against someone else on your own machine, and nobody else from another machine has joined your lobby, the overlay hides itself entirely — there's no one else to sync with, so it just stays out of the way.
 
 
-## Screenshots
+## Local versus games skip the manual ready-up
 
-![Title Screen](https://i.imgur.com/txGZj2Ul.png)
-![Gameplay](https://i.imgur.com/6PRBIHil.png)
-![twenty-one nine gameplay](https://i.imgur.com/rl6WibDl.png)
-![Player Options](https://i.imgur.com/Jk5A4LTl.png)
-![Evaluation](https://i.imgur.com/VamMT1Ql.png)
-![Select Profile](https://i.imgur.com/1SsDc90l.png)
-![Visual Themes](https://i.imgur.com/AQeRafLl.png)
-
-Check out this imgur album for more screenshots: [http://imgur.com/a/56wDq](http://imgur.com/a/56wDq)
+If you and a friend are playing local versus and you're the only two people in the lobby (i.e. no one from another machine has joined), both sides now auto-ready and gameplay starts immediately, rather than requiring you to each press Start to ready up. As soon as a third player from another machine joins your lobby, the normal ready-up flow returns.
 
 
----
+## Tournament Mode score comparisons now consider the whole lobby
 
-# Guides
+Previously, "who's winning" score highlighting (and the equivalent view in Step Statistics) only ever compared you against your local versus opponent. Now, during a Tournament Mode event with EX scoring, while connected to a lobby:
 
-### Installing Simply Love
+- Your score display dims unless you're currently in **1st place across the entire lobby** — not just ahead of whoever's next to you on the same machine.
+- This works even if you're the only person playing on your machine; you're compared against everyone else in the lobby, not just a local opponent.
+- If you and a friend are playing local versus and nobody else from another machine has joined, this falls back to the familiar local-only comparison, since the whole lobby is just the two of you anyway.
 
-[Installing Simply Love](./Other/Documentation/InstallingSimplyLove-README.md)
-
-### Profile Avatars
-
-[Profile Avatars](./Other/Documentation/ProfileAvatars-README.md)
-
-### Custom Songs from USB
-
-[Custom Songs from USB](./Other/Documentation/CustomSongsFromUSB-README.md)
-
-### Casual Mode
-
-<p>Casual Mode was designed with public arcade machines and casual players in mind. Learn more here:</p>
-
-[Casual Mode](./Other/Documentation/CasualMode-README.md)
-
-### Tips for installing StepMania
-
-[Troubleshooting StepMania](./Other/Documentation/TroubleshootingStepMania-README.md)
+Outside of a Tournament Mode + EX scoring lobby event, score dimming behaves exactly as it always has.
 
 
-## Hardware Guides
+## Step Statistics visibility fixes
 
-### Buying a 4-Panel Dance Pad
+A couple of display bugs affecting the Step Statistics pane during online lobby play have been fixed:
 
-*Dom ITG* has an excellent summary of 4-panel dance pad available in 2020:<br/>
-https://www.youtube.com/watch?v=sEWj2_BNG_0
+- The versus-style, split-screen Step Statistics layout no longer incorrectly appears for a single local player just because other players happen to be in the same online lobby — it now only shows up when there are actually two people playing on the same machine.
+- When Tournament Mode is on and only one local player is on the machine, Step Statistics now correctly forces itself on for that player (matching the versus-mode behavior), rather than requiring the player to have manually selected it beforehand.
 
-### USB Polling Issues
 
-[USB Polling Issues](./Other/Documentation/USBPollingIssues-README.md)
+## Fantastic+ (W0) counts always shown during Tournament Mode EX scoring events
 
-### Linux for a Dedicated SM5 PC
-
-<p>
-  din maintains a Linux image for running SM5 on common arcade hardware:<br/>
-  https://dinsfire.com/itgimage
-</p>
-
-<p>
-  It streamlines the setup process for those who have arcade hardware and
-  want to start playing as quickly as possible.
-</p>
+When Tournament Mode is enabled with EX scoring, Step Statistics now always breaks out Fantastic+ (W0) counts separately, regardless of whether you've personally turned on the Fantastic+ window preference. This keeps stat displays consistent across all players in a tournament event.

--- a/Scripts/SL-OnlineHelpers.lua
+++ b/Scripts/SL-OnlineHelpers.lua
@@ -224,27 +224,33 @@ local OrderPlayers = function(data, localScreenName)
   -- incorrectly reporting all players as synchronized.
   local firstScreen = localScreenName
   -- Process the scoreScreens first so we can sort the players by score.
-  for player in ivalues(data.players) do
-    if firstScreen == nil then
-      firstScreen = player.screenName
-    end
+  -- pairs(), not ivalues()/#: the server's players array can have nil gaps
+  -- (e.g. a disconnected slot), and # is undefined on a table with holes, so
+  -- ivalues() can silently stop early and skip real entries. pairs() visits
+  -- every entry that's actually present.
+  for _, player in pairs(data.players) do
+    if player then
+      if firstScreen == nil then
+        firstScreen = player.screenName
+      end
 
-    if player.screenName ~= firstScreen then
-      updatedData.aux.allInSameScreen = false
-    end
+      if player.screenName ~= firstScreen then
+        updatedData.aux.allInSameScreen = false
+      end
 
-    if player.screenName == Branch.GameplayScreen() then
-      updatedData.aux.anyInGameplay = true
-    end
+      if player.screenName == Branch.GameplayScreen() then
+        updatedData.aux.anyInGameplay = true
+      end
 
-    if not player.ready then
-      updatedData.aux.allPlayersReady = false
-    end
+      if not player.ready then
+        updatedData.aux.allPlayersReady = false
+      end
 
-    for screen in ivalues(scoreScreens) do
-      if player.screenName == screen then
-        updatedData.players[#updatedData.players+1] = player
-        break
+      for screen in ivalues(scoreScreens) do
+        if player.screenName == screen then
+          updatedData.players[#updatedData.players+1] = player
+          break
+        end
       end
     end
   end
@@ -263,33 +269,35 @@ local OrderPlayers = function(data, localScreenName)
   end)
 
   -- Then add all the other players in other screens below.
-  for player in ivalues(data.players) do
-    if firstScreen == nil then
-      firstScreen = player.screenName
-    end
-
-    if player.screenName ~= firstScreen then
-      updatedData.aux.allInSameScreen = false
-    end
-
-    if player.screenName == Branch.GameplayScreen() then
-      updatedData.aux.anyInGameplay = true
-    end
-
-    if not player.ready then
-      updatedData.aux.allPlayersReady = false
-    end
-
-    local inScoreScreen = false
-    for screen in ivalues(scoreScreens) do
-      if player.screenName == screen then
-        inScoreScreen = true
-        break
+  for _, player in pairs(data.players) do
+    if player then
+      if firstScreen == nil then
+        firstScreen = player.screenName
       end
-    end
 
-    if not inScoreScreen then
-      updatedData.players[#updatedData.players+1] = player
+      if player.screenName ~= firstScreen then
+        updatedData.aux.allInSameScreen = false
+      end
+
+      if player.screenName == Branch.GameplayScreen() then
+        updatedData.aux.anyInGameplay = true
+      end
+
+      if not player.ready then
+        updatedData.aux.allPlayersReady = false
+      end
+
+      local inScoreScreen = false
+      for screen in ivalues(scoreScreens) do
+        if player.screenName == screen then
+          inScoreScreen = true
+          break
+        end
+      end
+
+      if not inScoreScreen then
+        updatedData.players[#updatedData.players+1] = player
+      end
     end
   end
 
@@ -365,8 +373,7 @@ local DisplayLobbyState = function(data, actor)
   -- hide the overlay entirely -- there's nothing another machine needs to
   -- sync with us on. As soon as a third player (from another machine) joins,
   -- the normal display logic below takes back over.
-  local stylename = GAMESTATE:GetCurrentStyle():GetName()
-  local isSoloVersus = stylename == "versus" and #updatedData.players == 2
+  local isSoloVersus = IsSoloVersus()
   -- None of the Player Options screens show the overlay.
   local hideOverlay = noOverlayScreens[screenName] or false
   if isSoloVersus then
@@ -513,6 +520,98 @@ GetGameModeDisplayText = function()
   return THEME:GetString("ScreenSelectPlayMode", SL.Global.GameMode)
 end
 
+-- Returns true if we're in an online lobby, in versus style, and the only two
+-- players in the lobby are our own two local sides (i.e. nobody else from
+-- another machine has joined). Callers should fall back to local-only
+-- behavior in that case -- there's no one else to compare/sync against.
+IsSoloVersus = function()
+  local handler = GetOnlineHandlerInstance()
+  if not (handler and handler.inLobby and handler.latestLobbyState and handler.latestLobbyState.players) then
+    return false
+  end
+  if GAMESTATE:GetCurrentStyle():GetName() ~= "versus" then
+    return false
+  end
+
+  -- Count via pairs(), not # -- see the comment in GetBestLobbyScore about
+  -- why # is unreliable on this array (it can contain nil gaps).
+  local count = 0
+  for _, player in pairs(handler.latestLobbyState.players) do
+    if player then
+      count = count + 1
+    end
+  end
+  return count == 2
+end
+
+-- Returns the best known score (EX or dance points %, per useExScore) across
+-- every player currently in the lobby, or nil if we're not in a lobby at all.
+-- Used so that "who's winning" comparisons can consider the whole lobby
+-- instead of just the local player(s).
+GetBestLobbyScore = function(useExScore)
+  local handler = GetOnlineHandlerInstance()
+  if not (handler and handler.inLobby and handler.latestLobbyState and handler.latestLobbyState.players) then
+    return nil
+  end
+
+  -- Use pairs(), not ivalues()/#, since the server's players array can have
+  -- nil gaps (e.g. a disconnected slot) -- the # operator's behavior on a
+  -- table with holes is undefined, so ivalues() can unpredictably see
+  -- anywhere from zero to all of the real entries depending on where the gap
+  -- falls. pairs() correctly visits every entry that's actually present.
+  local best = nil
+  for _, player in pairs(handler.latestLobbyState.players) do
+    if player then
+      local value = useExScore and player.exScore or player.score
+      if value ~= nil and (best == nil or value > best) then
+        best = value
+      end
+    end
+  end
+  return best
+end
+
+-- Returns this local player's own score (EX or dance points %, per useExScore)
+-- as last reported to the lobby, or nil if we're not in a lobby or haven't
+-- synced yet. Matched by profile name against the lobby roster.
+--
+-- Comparisons against GetBestLobbyScore should always pull "my score" from
+-- here too, rather than from local judgment tracking -- mixing a fresh local
+-- value against a lobby-synced "best" (which may include a stale, differently
+-- timed copy of yourself) can make you appear to be losing to your own past
+-- self even when nobody has actually passed you.
+GetLobbyScoreForPlayer = function(player, useExScore)
+  local handler = GetOnlineHandlerInstance()
+  if not (handler and handler.inLobby and handler.latestLobbyState and handler.latestLobbyState.players) then
+    return nil
+  end
+
+  local profileName = "NoName"
+  if PROFILEMAN:IsPersistentProfile(player) and PROFILEMAN:GetProfile(player) then
+    profileName = PROFILEMAN:GetProfile(player):GetDisplayName()
+  end
+
+  -- See the comment in GetBestLobbyScore about why pairs() is used here
+  -- instead of ivalues()/#.
+  for _, entry in pairs(handler.latestLobbyState.players) do
+    if entry and entry.profileName == profileName then
+      local value = useExScore and entry.exScore or entry.score
+      if value ~= nil then
+        return value
+      end
+    end
+  end
+  return nil
+end
+
+-- Tournament Mode with EX scoring forces every player's ShowExScore to true
+-- (see SaveSelections in SL-PlayerOptions.lua), so callers gated on this can
+-- always treat scores as EX scores without branching on each player's own
+-- ShowExScore preference or worrying about mismatched scoring mechanisms.
+IsTournamentModeEX = function()
+  return ThemePrefs.Get("EnableTournamentMode") and ThemePrefs.Get("ScoringSystem") == "EX"
+end
+
 CreateOnlineHandler = function() 
   if onlineHandler == nil then
     onlineHandler = Def.ActorFrame{
@@ -637,17 +736,14 @@ CreateOnlineHandler = function()
           end
 
           if screenName == Branch.GameplayScreen() then
-            -- In solo versus (versus style, and we're the only two players in
-            -- the lobby -- see isSoloVersus in DisplayLobbyState), auto-ready
-            -- both sides so gameplay starts immediately instead of waiting on
-            -- a manual Start press from each player.
-            local stylename = GAMESTATE:GetCurrentStyle():GetName()
-            local lobbyPlayers = self.latestLobbyState and self.latestLobbyState.players
-            local isSoloVersus = stylename == "versus" and lobbyPlayers and #lobbyPlayers == 2
+            -- In solo versus (see IsSoloVersus()), auto-ready both sides so
+            -- gameplay starts immediately instead of waiting on a manual
+            -- Start press from each player.
+            local isSoloVersus = IsSoloVersus()
 
             for player in ivalues(GAMESTATE:GetEnabledPlayers()) do
               local pn = ToEnumShortString(player)
-              readyState[pn] = isSoloVersus or false
+              readyState[pn] = isSoloVersus
             end
             -- Input callbacks get cleared out when we transition screens, so we don't need to worry about explicitly removing it.
             SCREENMAN:GetTopScreen():AddInputCallback(InputHandler)


### PR DESCRIPTION
## Summary (Written by Claude)

Extends the "who's currently winning" score-dimming feature (previously local-only: P1 vs P2 on the same machine) to also work against the whole online lobby during a Tournament Mode + EX scoring event — so a player racing remote opponents (even solo, with no local partner) gets dimmed unless they're actually in 1st place lobby-wide, not just ahead of whoever's next to them. Also fixes a real bug where the server's player roster array could contain `nil` gaps that broke iteration.

## Changes

### `Scripts/SL-OnlineHelpers.lua`

- Three new global helpers:
  - `IsSoloVersus()` — extracted from two places that computed it inline. True when in versus style and exactly 2 players are in the lobby, meaning nobody from another machine has joined.
  - `GetBestLobbyScore(useExScore)` — max EX/dance-points score across the whole lobby roster.
  - `GetLobbyScoreForPlayer(player, useExScore)` — a specific local player's own score, matched by profile name against that same roster. Used instead of live local judgment tracking so both sides of a "who's winning" comparison come from the same synced snapshot.
- `IsTournamentModeEX()` — the combined gate (`EnableTournamentMode and ScoringSystem == "EX"`). This specific combination matters because it forces every player's `ShowExScore` to `true`, so callers never need to branch on individual scoring preference or worry about mismatches.
- **Bug fix**: `OrderPlayers` and the three new helpers all switched from `ivalues(...)` to `pairs(...)` when iterating the server-sourced players array. `ivalues()` bounds its iteration using Lua's `#` operator, which has undefined behavior on a table with `nil` holes (e.g. a disconnected player's slot) — this caused a real crash (`attempt to index local 'player' (a nil value)`) and, even after adding nil-guards, unpredictable under-counting (sometimes seeing all 4 players, sometimes zero) that silently broke the dimming comparison. `pairs()` reliably visits every entry regardless of gaps.
- `DisplayLobbyState` and `ScreenChangedMessageCommand` now both call the shared `IsSoloVersus()` instead of duplicating the inline computation.

### `BGAnimations/ScreenGameplay overlay/WhoIsCurrentlyWinning.lua`

- `UseLobbyStandings` gates whether the actor's original 2-local-player/matching-scoring-mechanism requirement gets bypassed.
- When active, `WinningCommand` judges each locally-joined side independently against `GetBestLobbyScore`, using `GetLobbyScoreForPlayer` rather than local tracking.
- New `OnlineLobbyStateMessageCommand` re-triggers the check on remote score updates, not just local judgments.
- The gate is re-checked fresh on every `WinningCommand` call (not just the load-time snapshot), so a mid-song disconnect gracefully falls back to the original local-only comparison.

### `BGAnimations/ScreenGameplay underlay/Shared/VersusStepStatistics.lua`

- Mirrors the same `UseLobbyStandings` treatment: `ShouldDisplayStats`, `ShouldDisplayStatsForPlayer`, the `#Players > 1` guard, and the score-text visibility condition all gained an escape hatch so the pane and its EX-score-with-dimming text can appear for a solo local player in that specific lobby scenario, not just real local versus.
- The `scoringMechanismsMatch` pre-check (which used to gate whether the comparison even ran) moved into `RedrawWinningCommand`'s local-only fallback branch, since it's irrelevant/potentially wrong when lobby-wide standings are active.

## Test plan

- [x] Local 2-player versus, no lobby: dimming behavior unchanged from before this PR
- [x] Solo versus (2 local players, no other machine in lobby): still uses local-only comparison, not lobby-wide
- [x] Tournament Mode + EX scoring, single style, solo vs. remote opponents: dimming reflects lobby-wide standing, not just local comparison
- [x] Tournament Mode + EX scoring, 2 local players vs. remote opponents: each local player dimmed/undimmed independently based on lobby standing
- [x] Mid-song disconnect from lobby: gracefully falls back to local-only comparison without erroring
- [x] Verify no crash when a lobby player disconnects mid-session (tests the `pairs()` fix for roster gaps)
